### PR TITLE
CreateVolume: use suggested name if possible

### DIFF
--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -55,7 +55,6 @@ const (
 type Linstor struct {
 	LinstorConfig
 	log            *log.Entry
-	prefix         string
 	annotationsKey string
 }
 
@@ -70,9 +69,6 @@ func NewLinstor(cfg LinstorConfig) *Linstor {
 	l := &Linstor{LinstorConfig: cfg}
 
 	l.annotationsKey = "csi-volume-annotations"
-	// Used to namespace csi volumes and meet linstor naming requirements.
-	l.prefix = "csi-"
-
 	l.LogOut = cfg.LogOut
 
 	if cfg.LogFmt != nil {
@@ -90,7 +86,6 @@ func NewLinstor(cfg LinstorConfig) *Linstor {
 	l.log = log.WithFields(log.Fields{
 		"linstorCSIComponent": "client",
 		"annotationsKey":      l.annotationsKey,
-		"resourcePrefix":      l.prefix,
 		"controllers":         l.Controllers,
 	})
 
@@ -163,8 +158,8 @@ func (s *Linstor) resDeploymentConfigFromVolumeInfo(vol *volume.Info) (*lc.Resou
 
 	cfg.Controllers = s.Controllers
 
-	// Use ID's with prefix here to conform to linstor naming rules.
-	cfg.Name = s.prefix + vol.ID
+	// At this time vol.ID has to be a valid LINSTOR Name
+	cfg.Name = vol.ID
 
 	// TODO: Make don't extend volume size by 1 Kib, unless you have to.
 	cfg.SizeKiB = uint64(vol.SizeBytes/1024 + 1)
@@ -263,7 +258,7 @@ func (s *Linstor) GetByID(ID string) (*volume.Info, error) {
 	}
 
 	for _, rd := range list {
-		if rd.RscName == s.prefix+ID {
+		if rd.RscName == ID {
 			vol, err := s.resDefToVolume(rd)
 			if err != nil {
 				return nil, err

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -81,3 +81,75 @@ func TestDriver(t *testing.T) {
 	// Now call the test suite
 	sanity.Test(t, cfg)
 }
+
+func TestValidResourceName(t *testing.T) {
+	all := "all"
+	if err := validResourceName(all); err == nil {
+		t.Fatalf("Expected '%s' to be be an invalid keyword", all)
+	}
+
+	tooLong := "abcdefghijklmnopqrstuvwyzABCDEFGHIJKLMNOPQRSTUVWXYZ_______" // 49
+	if err := validResourceName(tooLong); err == nil {
+		t.Fatalf("Expected '%s' to be too long", tooLong)
+	}
+
+	utf8rune := "hello🐱kitty"
+	if err := validResourceName(utf8rune); err == nil {
+		t.Fatalf("Expected '%s' to fail, because of an utf rune", utf8rune)
+	}
+
+	invalid := "_-"
+	if err := validResourceName(invalid); err == nil {
+		t.Fatalf("Expected '%s' to fail, because it is an invalid name", invalid)
+	}
+
+	valid := "rck23"
+	if err := validResourceName(valid); err != nil {
+		t.Fatalf("Expected '%s' to be valid", valid)
+	}
+}
+
+func TestLinstorifyResourceName(t *testing.T) {
+	var unitTests = []struct {
+		in, out string
+		errExp  bool
+	}{
+		{
+			in:     "rck23",
+			out:    "rck23",
+			errExp: false,
+		}, {
+			in:     "hello🐱kitty",
+			out:    "hello_kitty",
+			errExp: false,
+		}, {
+			in:     "1be00fd3-d435-436f-be20-561418c62762",
+			out:    "LS_1be00fd3-d435-436f-be20-561418c62762",
+			errExp: false,
+		}, {
+			in:     "b1e00fd3-d435-436f-be20-561418c62762",
+			out:    "b1e00fd3-d435-436f-be20-561418c62762",
+			errExp: false,
+		}, {
+			in:     "abcdefghijklmnopqrstuvwyzABCDEFGHIJKLMNOPQRSTUVWXYZ_______", // 49
+			out:    "should fail",
+			errExp: true,
+		},
+	}
+
+	for _, test := range unitTests {
+		resName, err := linstorifyResourceName(test.in)
+		if test.errExp && err == nil {
+			t.Fatalf("Expected that rest '%s' returns an error\n", test.in)
+		} else if !test.errExp && err != nil {
+			t.Fatalf("Expected that rest '%s' does not return an error\n", test.in)
+		} else if test.errExp && err != nil {
+			continue
+		}
+
+		if resName != test.out {
+			t.Fatalf("Expected that input '%s' transforms to '%s', but got '%s'\n", test.in, test.out, resName)
+		}
+	}
+
+}


### PR DESCRIPTION
The key ideas here are:
- the linstorifyResourceName algorithm which generates valid LINSTOR names. I assume that eventually such functionality will land in LINSTOR itself. So for now do not push that to `golinstor`. I hope we can remove that code in the future.
- remove the prefix as it is not needed any more on this "global" level. but keep it in the driver itself.
- don't break existing resources.

Feedback is welcome. If OK, feel free to merge.

Regards, rck 