### PR TITLE
Implement NodeGetVolumeStats

### DIFF
--- a/cmd/linstor-csi/linstor-csi.go
+++ b/cmd/linstor-csi/linstor-csi.go
@@ -93,6 +93,7 @@ func main() {
 		driver.NodeID(*node),
 		driver.Snapshots(linstorClient),
 		driver.Storage(linstorClient),
+		driver.VolumeStatter(linstorClient),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8 // indirect
 	golang.org/x/net v0.0.0-20190613194153-d28f0bde5980 // indirect
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
-	golang.org/x/sys v0.0.0-20190613124609-5ed2794edfdc // indirect
+	golang.org/x/sys v0.0.0-20190613124609-5ed2794edfdc
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	golang.org/x/tools v0.0.0-20190613204242-ed0dc450797f // indirect

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190613124609-5ed2794edfdc h1:x+/QxSNkVFAC+v4pL1f6mZr1z+qgi+FoR8ccXZPVC10=
 golang.org/x/sys v0.0.0-20190613124609-5ed2794edfdc/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9 h1:1/DFK4b7JH8DmkqhUk48onnSfrPzImPoVxuomtbT2nk=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/alvaroloes/enumer v1.1.2/go.mod h1:FxrjvuXoDAx9isTJrv4c+T410zFi0DtXIT
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/container-storage-interface/spec v1.1.0 h1:qPsTqtR1VUPvMPeK0UnCZMtXaKGyyLPG8gj/wG6VqMs=
 github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
+github.com/container-storage-interface/spec v1.2.0 h1:bD9KIVgaVKKkQ/UbVUY9kCaH/CJbhNxe0eeB4JeJV2s=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -197,6 +198,7 @@ k8s.io/kubernetes v1.14.2 h1:Gdq2hPpttbaJBoClIanCE6WSu4IZReA54yhkZtvPUOo=
 k8s.io/kubernetes v1.14.2/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/kubernetes v1.14.10 h1:P9qsSUUdx0MZKtJH9kvTHFTZamOH/lZjdcpmDhx0C9g=
 k8s.io/kubernetes v1.14.10/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
+k8s.io/kubernetes v1.17.2 h1:g1UFZqFQsYx88xMUks4PKC6tsNcekxe0v06fcVGRwVE=
 k8s.io/utils v0.0.0-20190607212802-c55fbcfc754a h1:2jUDc9gJja832Ftp+QbDV0tVhQHMISFn01els+2ZAcw=
 k8s.io/utils v0.0.0-20190607212802-c55fbcfc754a/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -44,6 +44,7 @@ import (
 	"github.com/pborman/uuid"
 	logrus "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sys/unix"
 	"k8s.io/kubernetes/pkg/util/mount"
 )
 
@@ -912,6 +913,11 @@ func mkfsArgs(opts, source string) []string {
 	return append(strings.Split(opts, " "), source)
 }
 
+// IsNotMountPoint determines if a directory is a mountpoint.
+func (s *Linstor) IsNotMountPoint(target string) (bool, error) {
+	return s.mounter.IsNotMountPoint(target)
+}
+
 //Unmount unmounts the target. Operates locally on the machines where it is called.
 func (s *Linstor) Unmount(target string) error {
 	s.log.WithFields(logrus.Fields{
@@ -985,4 +991,22 @@ func nil404(e error) error {
 		return nil
 	}
 	return e
+}
+
+// GetVolumeStats determines filesystem usage.
+func (s *Linstor) GetVolumeStats(path string) (volume.VolumeStats, error) {
+	var statfs unix.Statfs_t
+	err := unix.Statfs(path, &statfs)
+	if err != nil {
+		return volume.VolumeStats{}, err
+	}
+
+	return volume.VolumeStats{
+		AvailableBytes:  int64(statfs.Bavail) * int64(statfs.Bsize),
+		TotalBytes:      int64(statfs.Blocks) * int64(statfs.Bsize),
+		UsedBytes:       (int64(statfs.Blocks) - int64(statfs.Bfree)) * int64(statfs.Bsize),
+		AvailableInodes: int64(statfs.Ffree),
+		TotalInodes:     int64(statfs.Files),
+		UsedInodes:      int64(statfs.Files) - int64(statfs.Ffree),
+	}, nil
 }

--- a/pkg/client/mock.go
+++ b/pkg/client/mock.go
@@ -205,6 +205,15 @@ func (s *MockStorage) CapacityBytes(ctx context.Context, params map[string]strin
 func (s *MockStorage) Mount(vol *volume.Info, source, target, fsType string, options []string) error {
 	return nil
 }
+
+func (s *MockStorage) IsNotMountPoint(target string) (bool, error) {
+	return true, nil
+}
+
 func (s *MockStorage) Unmount(target string) error {
 	return nil
+}
+
+func (s *MockStorage) GetVolumeStats(path string) (volume.VolumeStats, error) {
+	return volume.VolumeStats{}, nil
 }

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -464,8 +464,8 @@ type VolumeStats struct {
 	UsedInodes      int64
 }
 
-// Statter provides info about volume/filesystem usage.
-type Statter interface {
+// VolumeStatter provides info about volume/filesystem usage.
+type VolumeStatter interface {
 	// GetVolumeStats determines filesystem usage.
 	GetVolumeStats(path string) (VolumeStats, error)
 }

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -451,4 +451,21 @@ type Querier interface {
 type Mounter interface {
 	Mount(vol *Info, source, target, fsType string, options []string) error
 	Unmount(target string) error
+	IsNotMountPoint(target string) (bool, error)
+}
+
+// VolumeStats provides details about filesystem usage.
+type VolumeStats struct {
+	AvailableBytes  int64
+	TotalBytes      int64
+	UsedBytes       int64
+	AvailableInodes int64
+	TotalInodes     int64
+	UsedInodes      int64
+}
+
+// Statter provides info about volume/filesystem usage.
+type Statter interface {
+	// GetVolumeStats determines filesystem usage.
+	GetVolumeStats(path string) (VolumeStats, error)
 }


### PR DESCRIPTION
I need this to monitor filesystem usage of Linstor-backed PVs. While I could use other monitoring tools, it would be great to have it directly integrated into K8s.