### PR TITLE
Disable host network

### DIFF
--- a/examples/k8s/deploy/linstor-csi-1.16.yaml
+++ b/examples/k8s/deploy/linstor-csi-1.16.yaml
@@ -19,8 +19,6 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       serviceAccount: linstor-csi-controller-sa
-      hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: csi-provisioner
           image: quay.io/k8scsi/csi-provisioner:v1.2.0
@@ -227,8 +225,6 @@ spec:
     spec:
       priorityClassName: system-node-critical
       serviceAccount: linstor-csi-node-sa
-      hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: csi-node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0

--- a/examples/k8s/deploy/linstor-csi-1.17.yaml
+++ b/examples/k8s/deploy/linstor-csi-1.17.yaml
@@ -19,7 +19,6 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       serviceAccount: linstor-csi-controller-sa
-      hostNetwork: true
       containers:
         - name: csi-provisioner
           image: quay.io/k8scsi/csi-provisioner:v1.4.0
@@ -187,7 +186,6 @@ spec:
     spec:
       priorityClassName: system-node-critical
       serviceAccount: linstor-csi-node-sa
-      hostNetwork: true
       containers:
         - name: csi-node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0


### PR DESCRIPTION
Hi, linstor-csi plugin is working fine without host networking.
This parameter was given here by mistake, actually I'm not using hostNetwork in [kube-linstor](https://github.com/kvaps/kube-linstor/blob/master/helm/kube-linstor/templates/linstor-csi.yaml) project