### PR TITLE
Do not use DfltDisklessStorPool in balancer scheduler

### DIFF
--- a/pkg/topology/scheduler/balancer/balancer.go
+++ b/pkg/topology/scheduler/balancer/balancer.go
@@ -129,6 +129,10 @@ func getNodesUtil(ctx context.Context, nClient NodeLinstorClient, selectedNodes 
 		}
 
 		for _, sp := range spls {
+			if sp.ProviderKind == lapi.DISKLESS {
+				continue
+			}
+
 			nicName := sp.Props[PrefNicPropKey]
 			free := sp.FreeCapacity
 			total := sp.TotalCapacity


### PR DESCRIPTION
Linstor v1.4.2 introduced that DfltDisklessStorPool is not filtered which is breaking balancer scheduler. This is fix for that.