### PR TITLE
TLS mutual auth support

### DIFF
--- a/cmd/linstor-csi/linstor-csi.go
+++ b/cmd/linstor-csi/linstor-csi.go
@@ -78,7 +78,7 @@ func main() {
 		caPool := x509.NewCertPool()
 		ok := caPool.AppendCertsFromPEM([]byte(caPEM))
 		if !ok {
-			log.Fatal("failed to get a valid certificate from LS_CA_PEM")
+			log.Fatal("failed to get a valid certificate from LS_ROOT_CA")
 		}
 		h = &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{Certificates: []tls.Certificate{keyPair}, RootCAs: caPool, InsecureSkipVerify: *lsSkipTLSVerification}}}
 	}

--- a/cmd/linstor-csi/linstor-csi.go
+++ b/cmd/linstor-csi/linstor-csi.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"flag"
 	"net/http"
 	"net/url"
@@ -63,10 +64,29 @@ func main() {
 	if r <= 0 {
 		r = rate.Inf
 	}
+
+	// Setup HTTP client with optional TLS mutual auth.
+	h := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: *lsSkipTLSVerification}}}
+	certPEM, cert := os.LookupEnv("LS_USER_CERTIFICATE")
+	keyPEM, key := os.LookupEnv("LS_USER_KEY")
+	caPEM, ca := os.LookupEnv("LS_ROOT_CA")
+	if cert && key && ca {
+		keyPair, err := tls.X509KeyPair([]byte(certPEM), []byte(keyPEM))
+		if err != nil {
+			log.Fatal(err)
+		}
+		caPool := x509.NewCertPool()
+		ok := caPool.AppendCertsFromPEM([]byte(caPEM))
+		if !ok {
+			log.Fatal("failed to get a valid certificate from LS_CA_PEM")
+		}
+		h = &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{Certificates: []tls.Certificate{keyPair}, RootCAs: caPool, InsecureSkipVerify: *lsSkipTLSVerification}}}
+	}
+
 	c, err := lc.NewHighLevelClient(
 		lapi.BaseURL(u),
 		lapi.BasicAuth(&lapi.BasicAuthCfg{Username: os.Getenv("LS_USERNAME"), Password: os.Getenv("LS_PASSWORD")}),
-		lapi.HTTPClient(&http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: *lsSkipTLSVerification}}}),
+		lapi.HTTPClient(h),
 		lapi.Limit(r, *burst),
 		lapi.Log(&lapi.LogCfg{Level: *logLevel, Out: logOut, Formatter: logFmt}),
 	)


### PR DESCRIPTION
This PR implements TLS mutual auth support for the LINSTOR controller API endpoint.
You can now pass three additional environment variables to the `linstor-csi-plugin` containers:

1. `LS_USER_CERTIFICATE`: a client certificate that is trusted by the LINSTOR controller.
2. `LS_USER_KEY`: corresponding private key.
3. `LS_ROOT_CA`: certificate authority certificate (or chain) that the client will use to verify server certificates.

These variables might receive their values from a Kubernetes secret or be defined directly in the YAML spec.
All three variables must be set in order to activate TLS mutual auth. All of them must contain PEM-encoded data. If all three are set and some error occurs while parsing them, then `linstor-csi` fails with a fatal error.